### PR TITLE
Add DDP training script

### DIFF
--- a/src/training/ddp_trainer.py
+++ b/src/training/ddp_trainer.py
@@ -7,7 +7,11 @@ from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 from torch.cuda.amp import GradScaler, autocast
 from torch.utils.tensorboard import SummaryWriter
-from torch.optim.lr_scheduler import CosineAnnealingWarmRestarts
+from torch.optim.lr_scheduler import (
+    CosineAnnealingWarmRestarts,
+    ReduceLROnPlateau,
+    StepLR,
+)
 import numpy as np
 import os
 import pickle
@@ -249,6 +253,33 @@ class DDPTrainer:
             focal_gamma=getattr(self.config, 'focal_gamma', 2.0),
             normalize_weights=getattr(self.config, 'normalize_task_weights', True)
         )
+    def _create_scheduler(self, optimizer: torch.optim.Optimizer):
+        """Create a learning rate scheduler from configuration."""
+        sched_type = getattr(self.config, "scheduler", "cosine").lower()
+
+        if sched_type == "step":
+            return StepLR(
+                optimizer,
+                step_size=getattr(self.config, "scheduler_step_size", 10),
+                gamma=getattr(self.config, "scheduler_gamma", 0.1),
+            )
+        elif sched_type == "plateau":
+            return ReduceLROnPlateau(
+                optimizer,
+                mode="min",
+                factor=getattr(self.config, "scheduler_factor", 0.1),
+                patience=getattr(self.config, "scheduler_patience", 5),
+            )
+        elif sched_type == "none":
+            return None
+        else:
+            return CosineAnnealingWarmRestarts(
+                optimizer,
+                T_0=getattr(self.config, "scheduler_T0", 10),
+                T_mult=getattr(self.config, "scheduler_T_mult", 2),
+                eta_min=getattr(self.config, "scheduler_eta_min", 1e-6),
+            )
+
     
     def calculate_loss(self, outputs: Dict[str, torch.Tensor], 
                       labels: Dict[str, torch.Tensor]) -> Tuple[torch.Tensor, Dict[str, torch.Tensor]]:
@@ -387,13 +418,8 @@ class DDPTrainer:
             eps=1e-8
         )
         
-        # Cosine annealing with warm restarts
-        scheduler = CosineAnnealingWarmRestarts(
-            optimizer, 
-            T_0=getattr(self.config, 'scheduler_T0', 10),
-            T_mult=getattr(self.config, 'scheduler_T_mult', 2),
-            eta_min=getattr(self.config, 'scheduler_eta_min', 1e-6)
-        )
+        # Learning rate scheduler
+        scheduler = self._create_scheduler(optimizer)
         
         # Mixed precision scaler
         scaler = GradScaler(enabled=getattr(self.config, 'mixed_precision', True))
@@ -437,7 +463,11 @@ class DDPTrainer:
                 val_loss = val_loss_tensor.item() / self.config.world_size
             
             # Learning rate scheduling
-            scheduler.step()
+            if scheduler:
+                if isinstance(scheduler, ReduceLROnPlateau):
+                    scheduler.step(val_loss)
+                else:
+                    scheduler.step()
             
             # Calculate average validation accuracy
             avg_val_acc = np.mean(list(val_accuracies.values()))
@@ -608,3 +638,4 @@ class DDPTrainer:
         """Cleanup distributed training"""
         if self.config.distributed:
             dist.destroy_process_group()
+

--- a/train_cv_folds.py
+++ b/train_cv_folds.py
@@ -1,0 +1,100 @@
+import argparse
+import pandas as pd
+import torch
+import torch.multiprocessing as mp
+from types import SimpleNamespace
+
+from src.training.ddp_trainer import DDPTrainer
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="DDP cross-validation using pre-assigned folds")
+    parser.add_argument('--csv', required=True, help='Metadata CSV with fold column')
+    parser.add_argument('--output-dir', default='runs', help='Directory for models and logs')
+    parser.add_argument('--epochs', type=int, default=10)
+    parser.add_argument('--batch-size', type=int, default=32)
+    parser.add_argument('--num-workers', type=int, default=4)
+    parser.add_argument('--lr', type=float, default=1e-4)
+    parser.add_argument('--scheduler', type=str, default='cosine',
+                        choices=['cosine', 'plateau', 'step', 'none'],
+                        help='Learning rate scheduler type')
+    parser.add_argument('--backbone', type=str, default='resnet18')
+    parser.add_argument('--port', type=int, default=12355,
+                        help='Port for distributed training init')
+    return parser.parse_args()
+
+
+def build_config(args, rank, n_splits):
+    cfg = SimpleNamespace()
+    cfg.csv_path = args.csv  # for logging/reference
+    cfg.output_dir = args.output_dir
+    cfg.epochs = args.epochs
+    cfg.batch_size = args.batch_size
+    cfg.num_workers = args.num_workers
+    cfg.lr = args.lr
+    cfg.scheduler = args.scheduler
+    cfg.backbone = args.backbone
+    cfg.dropout_rate = 0.2
+    cfg.feature_dim = 512
+    cfg.n_splits = n_splits
+
+    # Multi-task setup
+    cfg.num_classes = {'pathology': 2, 'region': 3, 'depth': 2}
+    cfg.task_weights = {'pathology': 1.0, 'region': 1.0, 'depth': 1.0}
+
+    # DDP settings
+    cfg.distributed = True
+    cfg.world_size = 4
+    cfg.rank = rank
+    cfg.local_rank = rank
+    cfg.dist_backend = 'nccl'
+    cfg.dist_url = f'tcp://127.0.0.1:{args.port}'
+    cfg.device = 'cuda'
+
+    # Other options
+    cfg.mixed_precision = True
+    cfg.log_every_n_batches = 50
+    cfg.save_best_model = True
+
+    return cfg
+
+
+def main_worker(rank, args, df, fold_ids):
+    config = build_config(args, rank, len(fold_ids))
+    trainer = DDPTrainer(config)
+
+    # Prepare folds only on rank 0 then broadcast
+    if rank == 0:
+        folds = [(
+            df[df['fold'] != k].reset_index(drop=True),
+            df[df['fold'] == k].reset_index(drop=True)
+        ) for k in fold_ids]
+    else:
+        folds = None
+
+    folds, _ = trainer._broadcast_dataframes(folds, df)
+
+    all_results = []
+    for fold_idx, (train_df, val_df) in enumerate(folds):
+        test_df = val_df  # no separate test set
+        fold_res = trainer.train_fold(fold_idx, train_df, val_df, test_df)
+        all_results.append(fold_res)
+
+    if rank == 0:
+        trainer._print_cv_results(all_results)
+
+    trainer.cleanup()
+
+
+def main():
+    args = parse_args()
+    df = pd.read_csv(args.csv)
+    if 'fold' not in df.columns:
+        raise ValueError("CSV must contain a 'fold' column")
+    fold_ids = sorted(df['fold'].unique())
+    mp.spawn(main_worker, nprocs=4, args=(args, df, fold_ids))
+
+
+if __name__ == '__main__':
+    main()

--- a/train_ddp.py
+++ b/train_ddp.py
@@ -1,0 +1,83 @@
+import argparse
+import torch
+import torch.multiprocessing as mp
+from types import SimpleNamespace
+
+from src.training.ddp_trainer import DDPTrainer
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="DDP training script")
+    parser.add_argument('--csv', required=True, help='Path to metadata CSV')
+    parser.add_argument('--output-dir', default='runs', help='Directory for models and logs')
+    parser.add_argument('--epochs', type=int, default=10)
+    parser.add_argument('--batch-size', type=int, default=32)
+    parser.add_argument('--num-workers', type=int, default=4)
+    parser.add_argument('--lr', type=float, default=1e-4)
+    parser.add_argument('--scheduler', type=str, default='cosine',
+                        choices=['cosine', 'plateau', 'step', 'none'],
+                        help='Learning rate scheduler type')
+    parser.add_argument('--backbone', type=str, default='resnet18')
+    parser.add_argument('--n-splits', type=int, default=5,
+                        help='Number of cross-validation folds')
+    parser.add_argument('--holdout-frac', type=float, default=0.2,
+                        help='Fraction of data to reserve for testing')
+    parser.add_argument('--seed', type=int, default=42,
+                        help='Random seed for data splitting')
+    parser.add_argument('--port', type=int, default=12355,
+                        help='Port for distributed training init')
+    return parser.parse_args()
+
+
+def build_config(args, rank):
+    cfg = SimpleNamespace()
+    # Dataset and model settings
+    cfg.csv_path = args.csv
+    cfg.output_dir = args.output_dir
+    cfg.epochs = args.epochs
+    cfg.batch_size = args.batch_size
+    cfg.num_workers = args.num_workers
+    cfg.lr = args.lr
+    cfg.scheduler = args.scheduler
+    cfg.backbone = args.backbone
+    cfg.n_splits = args.n_splits
+    cfg.holdout_frac = args.holdout_frac
+    cfg.random_seed = args.seed
+    cfg.dropout_rate = 0.2
+    cfg.feature_dim = 512
+
+    # Multi-task setup
+    cfg.num_classes = {'pathology': 2, 'region': 3, 'depth': 2}
+    cfg.task_weights = {'pathology': 1.0, 'region': 1.0, 'depth': 1.0}
+
+    # DDP parameters
+    cfg.distributed = True
+    cfg.world_size = 4
+    cfg.rank = rank
+    cfg.local_rank = rank
+    cfg.dist_backend = 'nccl'
+    cfg.dist_url = f'tcp://127.0.0.1:{args.port}'
+    cfg.device = 'cuda'
+
+    # Other options
+    cfg.mixed_precision = True
+    cfg.log_every_n_batches = 50
+    cfg.save_best_model = True
+
+    return cfg
+
+
+def main_worker(rank, args):
+    config = build_config(args, rank)
+    trainer = DDPTrainer(config)
+    trainer.train_cross_validation()
+    trainer.cleanup()
+
+
+def main():
+    args = parse_args()
+    mp.spawn(main_worker, nprocs=4, args=(args,))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a helper script to launch multi-GPU training with DDP
- enable flexible learning-rate schedulers in `DDPTrainer`
- add DDP cross-validation driver when folds are pre-computed
- fix configuration for dynamic CV script

## Testing
- `python -m py_compile train_cv_folds.py train_ddp.py src/training/ddp_trainer.py`


------
https://chatgpt.com/codex/tasks/task_e_6850ab28f74c8331a95fee20c1fc4169