### PR TITLE
Support precomputed class weights in DDP training

### DIFF
--- a/src/training/ddp_trainer.py
+++ b/src/training/ddp_trainer.py
@@ -61,7 +61,8 @@ class DDPTrainer:
             os.makedirs(os.path.join(config.output_dir, 'models'), exist_ok=True)
             os.makedirs(os.path.join(config.output_dir, 'logs'), exist_ok=True)
         
-        self.class_weights = None
+        # Allow passing pre-computed class weights through the config
+        self.class_weights = getattr(config, "class_weights", None)
         
         # Initialize evaluator
         self.evaluator = ModelEvaluator(config)
@@ -178,25 +179,24 @@ class DDPTrainer:
             transform=get_em_transforms(image_size=self.image_size, is_training=False)
         )
         
-        # Calculate class weights (only on rank 0, then broadcast)
-        if not self.config.distributed or self.config.rank == 0:
-            self.class_weights = self.calculate_class_weights(train_dataset)
-        
-        # Broadcast class weights to all processes
-        if self.config.distributed:
-            if self.config.rank == 0:
-                # Serialize class weights for broadcasting
-                class_weights_data = {task: weights.cpu() for task, weights in self.class_weights.items()}
-            else:
-                class_weights_data = None
-            
-            # Broadcast using pickle (simplified approach)
-            class_weights_list = [class_weights_data]
-            dist.broadcast_object_list(class_weights_list, src=0)
-            
-            if self.config.rank != 0:
-                class_weights_data = class_weights_list[0]
-                self.class_weights = {task: weights.to(self.device) for task, weights in class_weights_data.items()}
+        # Calculate or load class weights only if not already provided
+        if self.class_weights is None:
+            if not self.config.distributed or self.config.rank == 0:
+                self.class_weights = self.calculate_class_weights(train_dataset)
+
+            # Broadcast class weights to all processes
+            if self.config.distributed:
+                if self.config.rank == 0:
+                    class_weights_data = {task: w.cpu() for task, w in self.class_weights.items()}
+                else:
+                    class_weights_data = None
+
+                class_weights_list = [class_weights_data]
+                dist.broadcast_object_list(class_weights_list, src=0)
+
+                if self.config.rank != 0:
+                    class_weights_data = class_weights_list[0]
+                    self.class_weights = {task: w.to(self.device) for task, w in class_weights_data.items()}
         
         # Create samplers for distributed training
         if self.config.distributed:

--- a/train_ddp.py
+++ b/train_ddp.py
@@ -2,6 +2,9 @@ import argparse
 import torch
 import torch.multiprocessing as mp
 from types import SimpleNamespace
+import pandas as pd
+
+from src.data.utils import get_class_weights
 
 from src.training.ddp_trainer import DDPTrainer
 
@@ -29,7 +32,7 @@ def parse_args():
     return parser.parse_args()
 
 
-def build_config(args, rank, world_size):
+def build_config(args, rank, world_size, class_weights):
     cfg = SimpleNamespace()
     # Dataset and model settings
     cfg.csv_path = args.csv
@@ -67,12 +70,13 @@ def build_config(args, rank, world_size):
     cfg.mixed_precision = True
     cfg.log_every_n_batches = 50
     cfg.save_best_model = True
+    cfg.class_weights = class_weights
 
     return cfg
 
 
-def main_worker(rank, args, world_size):
-    config = build_config(args, rank, world_size)
+def main_worker(rank, args, world_size, class_weights):
+    config = build_config(args, rank, world_size, class_weights)
     trainer = DDPTrainer(config)
     trainer.train_cross_validation()
     trainer.cleanup()
@@ -83,7 +87,10 @@ def main():
     world_size = torch.cuda.device_count()
     if world_size == 0:
         world_size = 1  # fallback to CPU training
-    mp.spawn(main_worker, nprocs=world_size, args=(args, world_size))
+    df = pd.read_csv(args.csv)
+    tasks = ['pathology', 'region', 'depth']
+    class_weights = get_class_weights(df, tasks)
+    mp.spawn(main_worker, nprocs=world_size, args=(args, world_size, class_weights))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- allow `DDPTrainer` to read precomputed class weights
- modify dataloader logic to skip weight computation when provided
- compute class weights in `train_cv_folds.py` and `train_ddp.py` before spawning workers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68530f130ab48331a3f0897da99954fb