### PR TITLE
Fix deprecated autocast usage

### DIFF
--- a/src/training/ddp_trainer.py
+++ b/src/training/ddp_trainer.py
@@ -5,7 +5,8 @@ import torch.distributed as dist
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
-from torch.cuda.amp import GradScaler, autocast
+from torch.cuda.amp import GradScaler
+from torch.amp import autocast
 from torch.utils.tensorboard import SummaryWriter
 from torch.optim.lr_scheduler import (
     CosineAnnealingWarmRestarts,
@@ -336,7 +337,7 @@ class DDPTrainer:
             
             optimizer.zero_grad()
             
-            with autocast(enabled=getattr(self.config, 'mixed_precision', True)):
+            with autocast("cuda", enabled=getattr(self.config, 'mixed_precision', True)):
                 outputs = model(images)
                 loss, task_losses = self.calculate_loss(outputs, labels)
 

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -2,7 +2,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
-from torch.cuda.amp import GradScaler, autocast
+from torch.cuda.amp import GradScaler
+from torch.amp import autocast
 from torch.utils.tensorboard import SummaryWriter
 from torch.optim.lr_scheduler import CosineAnnealingWarmRestarts
 import numpy as np
@@ -175,7 +176,7 @@ class CNNTrainer:
             
             optimizer.zero_grad()
             
-            with autocast(enabled=self.config.mixed_precision):
+            with autocast("cuda", enabled=self.config.mixed_precision):
                 outputs = model(images)
                 loss, task_losses = self.calculate_loss(outputs, labels)
             


### PR DESCRIPTION
## Summary
- use `torch.amp.autocast` rather than deprecated `torch.cuda.amp.autocast`
- update ddp_trainer and trainer accordingly

## Testing
- `python -m py_compile src/training/ddp_trainer.py src/training/trainer.py`

------
https://chatgpt.com/codex/tasks/task_e_68536293346c83319cbfa560198b4c10