### PR TITLE
Add single task region CV script

### DIFF
--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,34 +1,13 @@
-# Import classes from your existing files
-try:
-    from .datasets import EMAxonDataset
-except ImportError:
-    print("Warning: Could not import EMAxonDataset from datasets")
-    EMAxonDataset = None
+from .datasets import EMAxonDataset, LabeledEMDataset, PathDepthPairDataset
+from .transforms import get_em_transforms, get_backbone_image_size
+from .utils import create_splits, create_splits_from_existing
 
-try:
-    from .datasets import LabeledEMDataset
-except ImportError:
-    print("Warning: Could not import LabeledEMDataset from datasets")
-    LabeledEMDataset = None
-
-
-try:
-    from .transforms import get_em_transforms, get_backbone_image_size
-except ImportError:
-    print("Warning: Could not import from transforms")
-    get_em_transforms = None
-
-try:
-    from .utils import create_splits
-except ImportError:
-    print("Warning: Could not import create_splits from utils")
-    create_splits = None
-
-try:
-    from .utils import create_splits_from_existing
-except ImportError:
-    print("Warning: Could not import create_splits_from_existing from utils")
-    create_splits = None
-
-# Make available for import
-__all__ = ['EMAxonDataset', 'LabeledEMDataset', 'get_em_transforms', 'create_splits', 'get_backbone_image_size', 'create_splits_from_existing']
+__all__ = [
+    'EMAxonDataset',
+    'LabeledEMDataset',
+    'PathDepthPairDataset',
+    'get_em_transforms',
+    'get_backbone_image_size',
+    'create_splits',
+    'create_splits_from_existing',
+]

--- a/src/data/datasets.py
+++ b/src/data/datasets.py
@@ -4,14 +4,16 @@ from PIL import Image
 import pandas as pd
 from typing import Dict, Optional, Callable
 
+
 class EMAxonDataset(Dataset):
-    """Dataset for EM axon cross-section images with multi-task labels"""
-    
-    def __init__(self, 
-                 df: pd.DataFrame, 
+    """Dataset for EM axon cross-section images with multi-task labels."""
+
+    def __init__(self,
+                 df: pd.DataFrame,
                  transform: Optional[Callable] = None,
                  task_mapping: Optional[Dict] = None):
-        """
+        """Create dataset from dataframe.
+
         Args:
             df: DataFrame with columns ['filepath', 'pathology', 'region', 'depth']
             transform: Image transformations
@@ -19,66 +21,80 @@ class EMAxonDataset(Dataset):
         """
         self.df = df.reset_index(drop=True)
         self.transform = transform
-        
+
         # Default task mapping
         if task_mapping is None:
             self.task_mapping = {
-                'pathology': {'Control': 0, 'ASD': 1},  # Assuming ASD is the pathology
+                'pathology': {'Control': 0, 'ASD': 1},
                 'region': {'A25': 0, 'A46': 1, 'OFC': 2},
-                'depth': {'DWM': 0, 'SWM': 1}  
+                'depth': {'DWM': 0, 'SWM': 1},
             }
         else:
             self.task_mapping = task_mapping
-    
+
     def __len__(self) -> int:
         return len(self.df)
-    
-    def __getitem__(self, idx: int) -> tuple:
+
+    def __getitem__(self, idx: int):
         row = self.df.iloc[idx]
-        
-        # Load and transform image
-        try:
-            img = Image.open(row['filepath']).convert('RGB')
-            if self.transform:
-                img = self.transform(img)
-        except Exception as e:
-            raise RuntimeError(f"Error loading image {row['filepath']}: {e}")
-        
-        # Create labels using mapping
+
+        img = Image.open(row['filepath']).convert('RGB')
+        if self.transform:
+            img = self.transform(img)
+
         labels = {}
         for task, mapping in self.task_mapping.items():
             if row[task] in mapping:
                 labels[task] = mapping[row[task]]
             else:
-                # Handle unknown labels
-                labels[task] = 0  # Default to first class
-                print(f"Warning: Unknown {task} value '{row[task]}' in row {idx}")
-        
+                labels[task] = 0
         return img, labels
-    
+
     def get_class_distribution(self) -> Dict[str, Dict]:
-        """Get class distribution for each task"""
         distribution = {}
         for task in self.task_mapping.keys():
             if task in self.df.columns:
                 distribution[task] = self.df[task].value_counts().to_dict()
         return distribution
 
+
 class LabeledEMDataset(EMAxonDataset):
-    """Modified dataset for classification labels"""
-    
+    """Example dataset returning the standard label mapping."""
+
     def __getitem__(self, idx):
         row = self.df.iloc[idx]
-        
-        # Load image
         img = Image.open(row['filepath']).convert('RGB')
         if self.transform:
             img = self.transform(img)
-        
-        # Create labels using the same mapping as your original EMAxonDataset
         labels = {
             'pathology': 0 if row['pathology'] == 'Control' else 1,
             'region': {'A25': 0, 'A46': 1, 'OFC': 2}[row['region']],
-            'depth': 0 if row['depth'] == 'DWM' else 1
+            'depth': 0 if row['depth'] == 'DWM' else 1,
         }
         return img, labels
+
+
+class PathDepthPairDataset(Dataset):
+    """Dataset that combines pathology and depth into a single label."""
+
+    def __init__(self, df: pd.DataFrame, transform: Optional[Callable] = None):
+        self.df = df.reset_index(drop=True)
+        self.transform = transform
+        self.label_mapping = {
+            ('Control', 'DWM'): 0,
+            ('Control', 'SWM'): 1,
+            ('ASD', 'DWM'): 2,
+            ('ASD', 'SWM'): 3,
+        }
+
+    def __len__(self) -> int:
+        return len(self.df)
+
+    def __getitem__(self, idx: int):
+        row = self.df.iloc[idx]
+        img = Image.open(row['filepath']).convert('RGB')
+        if self.transform:
+            img = self.transform(img)
+        label = self.label_mapping.get((row['pathology'], row['depth']), 0)
+        return img, {'pair': label}
+

--- a/train_region_single_cv.py
+++ b/train_region_single_cv.py
@@ -1,0 +1,137 @@
+import argparse
+import pandas as pd
+import torch
+import torch.multiprocessing as mp
+from types import SimpleNamespace
+import tempfile
+import os
+from sklearn.utils.class_weight import compute_class_weight
+import numpy as np
+
+from src.data import PathDepthPairDataset
+from src.training.ddp_trainer import DDPTrainer
+
+
+PAIR_MAPPING = {
+    ('Control', 'DWM'): 0,
+    ('Control', 'SWM'): 1,
+    ('ASD', 'DWM'): 2,
+    ('ASD', 'SWM'): 3,
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Cross-validation per region for single-task CNN"
+    )
+    parser.add_argument('--csv', required=True, help='Path to metadata CSV')
+    parser.add_argument('--output-dir', default='runs', help='Base directory for models and logs')
+    parser.add_argument('--epochs', type=int, default=10)
+    parser.add_argument('--batch-size', type=int, default=32)
+    parser.add_argument('--num-workers', type=int, default=4)
+    parser.add_argument('--lr', type=float, default=1e-4)
+    parser.add_argument('--scheduler', type=str, default='cosine',
+                        choices=['cosine', 'plateau', 'step', 'none'],
+                        help='Learning rate scheduler type')
+    parser.add_argument('--backbone', type=str, default='resnet18')
+    parser.add_argument('--n-splits', type=int, default=5,
+                        help='Number of cross-validation folds')
+    parser.add_argument('--holdout-frac', type=float, default=0.2,
+                        help='Fraction of data reserved for testing')
+    parser.add_argument('--seed', type=int, default=42,
+                        help='Random seed for data splitting')
+    parser.add_argument('--port', type=int, default=12355,
+                        help='Port for distributed training init')
+    return parser.parse_args()
+
+
+def compute_pair_class_weights(df: pd.DataFrame) -> dict:
+    labels = df[['pathology', 'depth']].apply(lambda r: PAIR_MAPPING[(r['pathology'], r['depth'])], axis=1)
+    classes = np.arange(len(PAIR_MAPPING))
+    weights = compute_class_weight('balanced', classes=classes, y=labels)
+    return {'pair': torch.tensor(weights, dtype=torch.float32)}
+
+
+def build_config(args, rank, world_size, class_weights, csv_path, region_name):
+    cfg = SimpleNamespace()
+    cfg.csv_path = csv_path
+    cfg.output_dir = os.path.join(args.output_dir, f"region_{region_name}")
+    cfg.epochs = args.epochs
+    cfg.batch_size = args.batch_size
+    cfg.num_workers = args.num_workers
+    cfg.lr = args.lr
+    cfg.scheduler = args.scheduler
+    cfg.backbone = args.backbone
+    cfg.n_splits = args.n_splits
+    cfg.holdout_frac = args.holdout_frac
+    cfg.random_seed = args.seed
+    cfg.dropout_rate = 0.2
+    cfg.feature_dim = 512
+
+    cfg.num_classes = {'pair': len(PAIR_MAPPING)}
+    cfg.task_weights = {'pair': 1.0}
+    cfg.model_type = 'single'
+    cfg.dataset_cls = PathDepthPairDataset
+
+    cfg.distributed = world_size > 1
+    cfg.world_size = world_size
+    cfg.rank = rank
+    cfg.local_rank = rank
+    if torch.cuda.is_available() and world_size > 0:
+        cfg.dist_backend = 'nccl'
+        cfg.device = 'cuda'
+    else:
+        cfg.dist_backend = 'gloo'
+        cfg.device = 'cpu'
+    cfg.dist_url = f'tcp://127.0.0.1:{args.port}'
+
+    cfg.mixed_precision = True
+    cfg.log_every_n_batches = 50
+    cfg.save_best_model = True
+    cfg.class_weights = class_weights
+
+    return cfg
+
+
+def main_worker(rank, args, csv_path, world_size, class_weights, region_name):
+    config = build_config(args, rank, world_size, class_weights, csv_path, region_name)
+    trainer = DDPTrainer(config)
+    trainer.train_cross_validation()
+    trainer.cleanup()
+
+
+def run_region(args, region_name, df_region):
+    world_size = torch.cuda.device_count()
+    if world_size == 0:
+        world_size = 1
+
+    class_weights = compute_pair_class_weights(df_region)
+
+    with tempfile.NamedTemporaryFile(suffix='.csv', delete=False) as tmp:
+        df_region.to_csv(tmp.name, index=False)
+        csv_path = tmp.name
+
+    mp.spawn(main_worker, nprocs=world_size,
+             args=(args, csv_path, world_size, class_weights, region_name))
+
+    os.remove(csv_path)
+
+
+def main():
+    args = parse_args()
+    df = pd.read_csv(args.csv)
+
+    if 'region' not in df.columns:
+        raise ValueError("CSV must contain a 'region' column")
+
+    regions = sorted(df['region'].unique())
+
+    for region in regions:
+        print(f"\n===== Training region: {region} =====")
+        df_region = df[df['region'] == region].reset_index(drop=True)
+        run_region(args, region, df_region)
+
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
## Summary
- add `PathDepthPairDataset` for combined pathology-depth labels
- expose new dataset via the data package
- extend `DDPTrainer` to accept custom dataset class and single-task models
- script `train_region_single_cv.py` trains a regular CNN on pair labels with cross‑validation

## Testing
- `pytest -q`
- `flake8` *(fails: numerous style warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685adc98cbb48331be5f308b789d50df