### PR TITLE
Modify region CV script for existing splits

### DIFF
--- a/train_region_cv.py
+++ b/train_region_cv.py
@@ -13,7 +13,10 @@ from src.training.ddp_trainer import DDPTrainer
 def parse_args():
     parser = argparse.ArgumentParser(
         description="Cross-validation per region using DDP")
-    parser.add_argument('--csv', required=True, help='Path to metadata CSV')
+    parser.add_argument('--train-val-csv', required=True,
+                        help='CSV containing training and validation data')
+    parser.add_argument('--test-csv', required=True,
+                        help='CSV containing the held-out test data')
     parser.add_argument('--output-dir', default='runs', help='Base directory for models and logs')
     parser.add_argument('--epochs', type=int, default=10)
     parser.add_argument('--batch-size', type=int, default=32)
@@ -25,8 +28,6 @@ def parse_args():
     parser.add_argument('--backbone', type=str, default='resnet18')
     parser.add_argument('--n-splits', type=int, default=5,
                         help='Number of cross-validation folds')
-    parser.add_argument('--holdout-frac', type=float, default=0.2,
-                        help='Fraction of data reserved for testing')
     parser.add_argument('--seed', type=int, default=42,
                         help='Random seed for data splitting')
     parser.add_argument('--port', type=int, default=12355,
@@ -34,9 +35,11 @@ def parse_args():
     return parser.parse_args()
 
 
-def build_config(args, rank, world_size, class_weights, csv_path, region_name):
+def build_config(args, rank, world_size, class_weights,
+                 train_val_path, test_path, region_name):
     cfg = SimpleNamespace()
-    cfg.csv_path = csv_path  # region-specific temporary CSV
+    cfg.train_val_csv_path = train_val_path
+    cfg.test_csv_path = test_path
     cfg.output_dir = os.path.join(args.output_dir, f"region_{region_name}")
     cfg.epochs = args.epochs
     cfg.batch_size = args.batch_size
@@ -45,7 +48,6 @@ def build_config(args, rank, world_size, class_weights, csv_path, region_name):
     cfg.scheduler = args.scheduler
     cfg.backbone = args.backbone
     cfg.n_splits = args.n_splits
-    cfg.holdout_frac = args.holdout_frac
     cfg.random_seed = args.seed
     cfg.dropout_rate = 0.2
     cfg.feature_dim = 512
@@ -76,44 +78,57 @@ def build_config(args, rank, world_size, class_weights, csv_path, region_name):
     return cfg
 
 
-def main_worker(rank, args, csv_path, world_size, class_weights, region_name):
-    config = build_config(args, rank, world_size, class_weights, csv_path, region_name)
+def main_worker(rank, args, train_val_path, test_path, world_size, class_weights, region_name):
+    config = build_config(args, rank, world_size, class_weights,
+                          train_val_path, test_path, region_name)
     trainer = DDPTrainer(config)
     trainer.train_cross_validation()
     trainer.cleanup()
 
 
-def run_region(args, region_name, df_region):
+def run_region(args, region_name, df_trainval_reg, df_test_reg):
     world_size = torch.cuda.device_count()
     if world_size == 0:
         world_size = 1
 
     tasks = ['pathology', 'depth']
-    class_weights = get_class_weight_tensors(df_region, tasks)
+    class_weights = get_class_weight_tensors(df_trainval_reg, tasks)
 
-    with tempfile.NamedTemporaryFile(suffix='.csv', delete=False) as tmp:
-        df_region.to_csv(tmp.name, index=False)
-        csv_path = tmp.name
+    with tempfile.NamedTemporaryFile(suffix='.csv', delete=False) as tmp_trainval, \
+         tempfile.NamedTemporaryFile(suffix='.csv', delete=False) as tmp_test:
+        df_trainval_reg.to_csv(tmp_trainval.name, index=False)
+        df_test_reg.to_csv(tmp_test.name, index=False)
+        train_path = tmp_trainval.name
+        test_path = tmp_test.name
 
-    mp.spawn(main_worker, nprocs=world_size,
-             args=(args, csv_path, world_size, class_weights, region_name))
+    mp.spawn(
+        main_worker,
+        nprocs=world_size,
+        args=(args, train_path, test_path, world_size, class_weights, region_name)
+    )
 
-    os.remove(csv_path)
+    os.remove(train_path)
+    os.remove(test_path)
 
 
 def main():
     args = parse_args()
-    df = pd.read_csv(args.csv)
 
-    if 'region' not in df.columns:
-        raise ValueError("CSV must contain a 'region' column")
+    df_trainval = pd.read_csv(args.train_val_csv)
+    df_test = pd.read_csv(args.test_csv)
 
-    regions = sorted(df['region'].unique())
+    for df in (df_trainval, df_test):
+        if 'region' not in df.columns:
+            raise ValueError("CSVs must contain a 'region' column")
+
+    regions = sorted(set(df_trainval['region'].unique()) |
+                     set(df_test['region'].unique()))
 
     for region in regions:
         print(f"\n===== Training region: {region} =====")
-        df_region = df[df['region'] == region].reset_index(drop=True)
-        run_region(args, region, df_region)
+        df_trainval_reg = df_trainval[df_trainval['region'] == region].reset_index(drop=True)
+        df_test_reg = df_test[df_test['region'] == region].reset_index(drop=True)
+        run_region(args, region, df_trainval_reg, df_test_reg)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- update `train_region_cv.py` to create splits from existing train/val and test CSVs
- adjust argument parsing for the new file paths

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b0f617a708331a4f9ed19c4b730c4