### PR TITLE
Fix multiprocessing start method

### DIFF
--- a/train_single_region_pathology.py
+++ b/train_single_region_pathology.py
@@ -113,7 +113,7 @@ def run_region(args, region_name, df_region, lr, dropout):
         df_region.to_csv(tmp.name, index=False)
         csv_path = tmp.name
 
-    result_queue = mp.SimpleQueue()
+    result_queue = mp.get_context('spawn').SimpleQueue()
     mp.spawn(
         main_worker,
         nprocs=world_size,
@@ -161,4 +161,5 @@ def main():
 
 
 if __name__ == '__main__':
+    torch.multiprocessing.set_start_method('spawn', force=True)
     main()


### PR DESCRIPTION
## Summary
- set torch multiprocessing to spawn mode before running script
- use spawn context for `SimpleQueue`

## Testing
- `python -m py_compile train_single_region_pathology.py`
- `pytest -q`
- `python train_single_region_pathology.py --csv tmp_data/meta.csv --region A25 --epochs 0 --n-splits 2 --holdout-frac 0.33 --batch-size 1 --num-workers 0 --num-trials 1` *(fails: ProxyError due to no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_686c8d15a5748331a7d30e69b330f7f1