### PR TITLE
Implement Noise2Void denoising module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # ASD_EM
+
+This repository contains utilities for electron microscopy (EM) analysis.  The
+`denoising` module implements a self‑supervised Noise2Void pipeline for gentle
+denoising of axon cross‑section images.
+
+## Noise2Void Usage
+
+### Training
+
+```
+python -m src.denoising.train_n2v \
+    --images /path/to/*.tif \
+    --output-dir n2v_runs \
+    --patch-size 64
+```
+Example denoised patches are saved to the output directory after each epoch for visual inspection.
+
+### Inference
+
+```
+python -m src.denoising.inference_n2v \
+    --image sample.tif \
+    --model n2v_runs/best.pt \
+    --output sample_denoised.tif
+```
+
+Validation utilities such as edge preservation and texture similarity are
+available in `src/denoising/validation.py`.

--- a/src/denoising/__init__.py
+++ b/src/denoising/__init__.py
@@ -1,0 +1,3 @@
+from .unet import UNet
+from .dataset import PatchDataset, load_image
+from .utils import generate_n2v_mask, apply_n2v_mask, n2v_loss

--- a/src/denoising/dataset.py
+++ b/src/denoising/dataset.py
@@ -1,0 +1,64 @@
+import os
+from typing import List, Tuple
+from PIL import Image
+import torch
+from torch.utils.data import Dataset
+import torchvision.transforms.functional as TF
+
+
+def load_image(path: str) -> Image.Image:
+    """Load an image from disk."""
+    with Image.open(path) as img:
+        return img.convert('L')
+
+
+def normalize(img: torch.Tensor) -> torch.Tensor:
+    """Normalize an image tensor to 0-1 range."""
+    img = img.float() / 255.0
+    return img
+
+
+def random_augment(img: torch.Tensor) -> torch.Tensor:
+    """Apply rotation and flip augmentations."""
+    if torch.rand(1) < 0.5:
+        img = TF.hflip(img)
+    if torch.rand(1) < 0.5:
+        img = TF.vflip(img)
+    # rotations in multiples of 90 degrees
+    k = torch.randint(0, 4, (1,)).item()
+    img = torch.rot90(img, k, [1, 2])
+    return img
+
+
+class PatchDataset(Dataset):
+    """Dataset that extracts patches from SEM images."""
+
+    def __init__(self, image_paths: List[str], patch_size: int = 64, overlap: int = 16,
+                 augment: bool = True):
+        self.image_paths = image_paths
+        self.patch_size = patch_size
+        self.overlap = overlap
+        self.augment = augment
+        self.patches: List[Tuple[str, Tuple[int, int]]] = []
+        self._index_patches()
+
+    def _index_patches(self):
+        for path in self.image_paths:
+            img = load_image(path)
+            w, h = img.size
+            step = self.patch_size - self.overlap
+            for y in range(0, h - self.patch_size + 1, step):
+                for x in range(0, w - self.patch_size + 1, step):
+                    self.patches.append((path, (x, y)))
+
+    def __len__(self) -> int:
+        return len(self.patches)
+
+    def __getitem__(self, idx: int) -> torch.Tensor:
+        path, (x, y) = self.patches[idx]
+        img = load_image(path)
+        patch = img.crop((x, y, x + self.patch_size, y + self.patch_size))
+        patch_t = normalize(TF.to_tensor(patch))
+        if self.augment:
+            patch_t = random_augment(patch_t)
+        return patch_t

--- a/src/denoising/inference_n2v.py
+++ b/src/denoising/inference_n2v.py
@@ -1,0 +1,63 @@
+import argparse
+import os
+from typing import List
+
+import torch
+from PIL import Image
+import torchvision.transforms.functional as TF
+from torch.utils.data import DataLoader
+
+from .dataset import PatchDataset, load_image
+from .unet import UNet
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Noise2Void inference")
+    p.add_argument('--image', required=True, help='Image to denoise')
+    p.add_argument('--model', required=True, help='Path to trained model')
+    p.add_argument('--patch-size', type=int, default=64)
+    p.add_argument('--overlap', type=int, default=16)
+    p.add_argument('--output', default='denoised.tif')
+    return p.parse_args()
+
+
+def reconstruct_from_patches(patches: List[torch.Tensor], img_size: tuple, patch_size: int, overlap: int) -> torch.Tensor:
+    step = patch_size - overlap
+    out = torch.zeros(img_size)
+    count = torch.zeros(img_size)
+    idx = 0
+    h, w = img_size
+    for y in range(0, h - patch_size + 1, step):
+        for x in range(0, w - patch_size + 1, step):
+            out[:, y:y+patch_size, x:x+patch_size] += patches[idx]
+            count[:, y:y+patch_size, x:x+patch_size] += 1
+            idx += 1
+    out /= count
+    return out
+
+
+def inference(args: argparse.Namespace):
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    model = UNet().to(device)
+    model.load_state_dict(torch.load(args.model, map_location=device))
+    model.eval()
+
+    img = load_image(args.image)
+    w, h = img.size
+    dataset = PatchDataset([args.image], patch_size=args.patch_size, overlap=args.overlap, augment=False)
+    loader = DataLoader(dataset, batch_size=1, shuffle=False)
+
+    patches = []
+    with torch.no_grad():
+        for patch in loader:
+            patch = patch.to(device)
+            pred = model(patch)
+            patches.append(pred.cpu())
+    denoised = reconstruct_from_patches(patches, (1, h, w), args.patch_size, args.overlap)
+    out_img = TF.to_pil_image(denoised.clamp(0, 1))
+    out_img.save(args.output)
+    print(f"Saved denoised image to {args.output}")
+
+
+if __name__ == '__main__':
+    inference(parse_args())

--- a/src/denoising/train_n2v.py
+++ b/src/denoising/train_n2v.py
@@ -1,0 +1,88 @@
+import argparse
+import os
+from typing import List
+
+import torch
+from torch.utils.data import DataLoader
+from torch.optim import Adam
+from torch.optim.lr_scheduler import ReduceLROnPlateau
+
+from .dataset import PatchDataset
+from .unet import UNet
+from .utils import generate_n2v_mask, apply_n2v_mask, n2v_loss, save_comparison
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Noise2Void training")
+    p.add_argument('--images', nargs='+', required=True, help='Image file paths')
+    p.add_argument('--output-dir', default='n2v_runs', help='Directory to save checkpoints')
+    p.add_argument('--patch-size', type=int, default=64)
+    p.add_argument('--overlap', type=int, default=16)
+    p.add_argument('--batch-size', type=int, default=16)
+    p.add_argument('--epochs', type=int, default=100)
+    p.add_argument('--lr', type=float, default=1e-4)
+    p.add_argument('--patience', type=int, default=10)
+    p.add_argument('--mask-ratio', type=float, default=0.03)
+    return p.parse_args()
+
+
+def train(args: argparse.Namespace):
+    os.makedirs(args.output_dir, exist_ok=True)
+    dataset = PatchDataset(args.images, patch_size=args.patch_size, overlap=args.overlap)
+    loader = DataLoader(dataset, batch_size=args.batch_size, shuffle=True, num_workers=4)
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    model = UNet().to(device)
+    opt = Adam(model.parameters(), lr=args.lr)
+    scheduler = ReduceLROnPlateau(opt, patience=5)
+
+    best_loss = float('inf')
+    no_improve = 0
+
+    # select example patch for visualization
+    aug_flag = dataset.augment
+    dataset.augment = False
+    example_patch = dataset[0].unsqueeze(0).to(device)
+    dataset.augment = aug_flag
+    for epoch in range(args.epochs):
+        model.train()
+        epoch_loss = 0.0
+        for batch in loader:
+            batch = batch.to(device)
+            mask = torch.stack([generate_n2v_mask(batch.shape[-2:], args.mask_ratio) for _ in range(batch.size(0))])
+            noisy, target_pixels = apply_n2v_mask(batch, mask)
+            pred = model(noisy)
+            loss = n2v_loss(pred, target_pixels, mask)
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+            epoch_loss += loss.item() * batch.size(0)
+        epoch_loss /= len(loader.dataset)
+        scheduler.step(epoch_loss)
+        print(f"Epoch {epoch+1} Loss {epoch_loss:.4f}")
+
+        # log example denoising result
+        model.eval()
+        with torch.no_grad():
+            example_pred = model(example_patch)
+        save_comparison(
+            example_patch.squeeze(0),
+            example_pred.squeeze(0).cpu(),
+            os.path.join(args.output_dir, f"epoch_{epoch+1}.png"),
+        )
+        model.train()
+
+        if epoch_loss < best_loss:
+            best_loss = epoch_loss
+            no_improve = 0
+            torch.save(model.state_dict(), os.path.join(args.output_dir, 'best.pt'))
+        else:
+            no_improve += 1
+            if no_improve >= args.patience:
+                print('Early stopping')
+                break
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    train(args)

--- a/src/denoising/unet.py
+++ b/src/denoising/unet.py
@@ -1,0 +1,62 @@
+import torch
+import torch.nn as nn
+
+
+class ConvBlock(nn.Module):
+    def __init__(self, in_channels: int, out_channels: int):
+        super().__init__()
+        self.conv = nn.Sequential(
+            nn.Conv2d(in_channels, out_channels, 3, padding=1),
+            nn.InstanceNorm2d(out_channels),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(out_channels, out_channels, 3, padding=1),
+            nn.InstanceNorm2d(out_channels),
+            nn.ReLU(inplace=True),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.conv(x)
+
+
+class UNet(nn.Module):
+    def __init__(self, in_channels: int = 1, out_channels: int = 1, base_features: int = 32, depth: int = 4):
+        super().__init__()
+        self.depth = depth
+        feats = [base_features * 2 ** i for i in range(depth)]
+
+        self.down_blocks = nn.ModuleList()
+        self.pools = nn.ModuleList()
+        prev_c = in_channels
+        for f in feats:
+            self.down_blocks.append(ConvBlock(prev_c, f))
+            self.pools.append(nn.MaxPool2d(2))
+            prev_c = f
+
+        self.bottleneck = ConvBlock(prev_c, prev_c * 2)
+        prev_c = prev_c * 2
+
+        self.up_blocks = nn.ModuleList()
+        self.ups = nn.ModuleList()
+        feats_rev = list(reversed(feats))
+        for f in feats_rev:
+            self.ups.append(nn.ConvTranspose2d(prev_c, f, 2, stride=2))
+            self.up_blocks.append(ConvBlock(prev_c, f))
+            prev_c = f
+
+        self.final_conv = nn.Conv2d(prev_c, out_channels, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        skips = []
+        for block, pool in zip(self.down_blocks, self.pools):
+            x = block(x)
+            skips.append(x)
+            x = pool(x)
+
+        x = self.bottleneck(x)
+
+        for up, block, skip in zip(self.ups, self.up_blocks, reversed(skips)):
+            x = up(x)
+            x = torch.cat([x, skip], dim=1)
+            x = block(x)
+
+        return self.final_conv(x)

--- a/src/denoising/utils.py
+++ b/src/denoising/utils.py
@@ -1,0 +1,43 @@
+import torch
+import torch.nn.functional as F
+from typing import Tuple
+from PIL import Image
+import torchvision.transforms.functional as TF
+
+
+def generate_n2v_mask(shape: Tuple[int, int], mask_ratio: float = 0.03, radius: int = 2) -> torch.Tensor:
+    """Generate random mask for Noise2Void."""
+    mask = torch.zeros(shape, dtype=torch.bool)
+    num_pixels = int(mask.numel() * mask_ratio)
+    coords = torch.stack(
+        [torch.randint(0, s, (num_pixels,)) for s in shape], dim=1
+    )
+    for y, x in coords:
+        y0 = max(y - radius, 0)
+        y1 = min(y + radius + 1, shape[0])
+        x0 = max(x - radius, 0)
+        x1 = min(x + radius + 1, shape[1])
+        mask[y0:y1, x0:x1] = True
+    return mask
+
+
+def apply_n2v_mask(img: torch.Tensor, mask: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    noisy_img = img.clone()
+    noise = torch.randn_like(noisy_img)
+    noisy_img[mask] = noise[mask]
+    return noisy_img, img[mask]
+
+
+def n2v_loss(pred: torch.Tensor, target_pixels: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+    return F.mse_loss(pred[mask], target_pixels)
+
+
+def save_comparison(original: torch.Tensor, denoised: torch.Tensor, path: str) -> None:
+    """Save side-by-side original and denoised images."""
+    orig_img = TF.to_pil_image(original.cpu().clamp(0, 1))
+    den_img = TF.to_pil_image(denoised.cpu().clamp(0, 1))
+    w, h = orig_img.size
+    canvas = Image.new('L', (w * 2, h))
+    canvas.paste(orig_img, (0, 0))
+    canvas.paste(den_img, (w, 0))
+    canvas.save(path)

--- a/src/denoising/validation.py
+++ b/src/denoising/validation.py
@@ -1,0 +1,21 @@
+import torch
+import torch.nn.functional as F
+from skimage.metrics import structural_similarity as ssim
+from typing import Tuple
+
+
+def edge_preservation(original: torch.Tensor, denoised: torch.Tensor) -> float:
+    """Compute edge preservation using Sobel gradients."""
+    sobel = torch.tensor([[1, 0, -1], [2, 0, -2], [1, 0, -1]], dtype=torch.float32)
+    sobel_x = sobel.view(1, 1, 3, 3)
+    sobel_y = sobel.t().view(1, 1, 3, 3)
+    grad_orig = F.conv2d(original, sobel_x, padding=1) ** 2 + F.conv2d(original, sobel_y, padding=1) ** 2
+    grad_deno = F.conv2d(denoised, sobel_x, padding=1) ** 2 + F.conv2d(denoised, sobel_y, padding=1) ** 2
+    return F.cosine_similarity(grad_orig.flatten(), grad_deno.flatten(), dim=0).item()
+
+
+def texture_similarity(original: torch.Tensor, denoised: torch.Tensor) -> float:
+    """Evaluate texture preservation using SSIM."""
+    orig_np = original.squeeze().cpu().numpy()
+    den_np = denoised.squeeze().cpu().numpy()
+    return ssim(orig_np, den_np, data_range=1.0)


### PR DESCRIPTION
## Summary
- add Noise2Void training/inference utilities under `src/denoising`
- provide lightweight UNet and dataset helpers
- include edge and texture validation functions
- document usage in README
- log example denoising result for each epoch during training

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m src.denoising.train_n2v --help | head -n 20`
- `python -m src.denoising.inference_n2v --help | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68743f4243008331a6c56258936aa272