### PR TITLE
Update Noise2Void training CLI to support CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ denoising of axon cross‑section images.
 
 ```
 python -m src.denoising.train_n2v \
-    --images /path/to/*.tif \
+    --csv train_paths.csv \
     --output-dir n2v_runs \
     --patch-size 64
 ```
+You can also provide image paths directly using the `--images` argument.
 Example denoised patches are saved to the output directory after each epoch for visual inspection.
 
 ### Inference

--- a/src/denoising/train_n2v.py
+++ b/src/denoising/train_n2v.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-from typing import List
 
 import torch
 from torch.utils.data import DataLoader
@@ -14,29 +13,62 @@ from .utils import generate_n2v_mask, apply_n2v_mask, n2v_loss, save_comparison
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Noise2Void training")
-    p.add_argument('--images', nargs='+', required=True, help='Image file paths')
-    p.add_argument('--output-dir', default='n2v_runs', help='Directory to save checkpoints')
-    p.add_argument('--patch-size', type=int, default=64)
-    p.add_argument('--overlap', type=int, default=16)
-    p.add_argument('--batch-size', type=int, default=16)
-    p.add_argument('--epochs', type=int, default=100)
-    p.add_argument('--lr', type=float, default=1e-4)
-    p.add_argument('--patience', type=int, default=10)
-    p.add_argument('--mask-ratio', type=float, default=0.03)
-    return p.parse_args()
+    p.add_argument(
+        "--images",
+        nargs="+",
+        help="Image file paths. Use this or --csv to specify training images.",
+    )
+    p.add_argument(
+        "--csv",
+        help=(
+            "CSV file containing a 'filepath' column with image paths. "
+            "Provides an alternative to --images."
+        ),
+    )
+    p.add_argument(
+        "--output-dir",
+        default="n2v_runs",
+        help="Directory to save checkpoints",
+    )
+    p.add_argument("--patch-size", type=int, default=64)
+    p.add_argument("--overlap", type=int, default=16)
+    p.add_argument("--batch-size", type=int, default=16)
+    p.add_argument("--epochs", type=int, default=100)
+    p.add_argument("--lr", type=float, default=1e-4)
+    p.add_argument("--patience", type=int, default=10)
+    p.add_argument("--mask-ratio", type=float, default=0.03)
+    args = p.parse_args()
+
+    # Load image paths from CSV if provided
+    if args.csv:
+        import pandas as pd
+
+        df = pd.read_csv(args.csv)
+        if "filepath" not in df.columns:
+            raise ValueError("CSV must contain a 'filepath' column")
+        args.images = df["filepath"].astype(str).tolist()
+
+    if not args.images:
+        p.error("Either --images or --csv must be specified")
+
+    return args
 
 
 def train(args: argparse.Namespace):
     os.makedirs(args.output_dir, exist_ok=True)
-    dataset = PatchDataset(args.images, patch_size=args.patch_size, overlap=args.overlap)
-    loader = DataLoader(dataset, batch_size=args.batch_size, shuffle=True, num_workers=4)
+    dataset = PatchDataset(
+        args.images, patch_size=args.patch_size, overlap=args.overlap
+    )
+    loader = DataLoader(
+        dataset, batch_size=args.batch_size, shuffle=True, num_workers=4
+    )
 
-    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model = UNet().to(device)
     opt = Adam(model.parameters(), lr=args.lr)
     scheduler = ReduceLROnPlateau(opt, patience=5)
 
-    best_loss = float('inf')
+    best_loss = float("inf")
     no_improve = 0
 
     # select example patch for visualization
@@ -49,7 +81,12 @@ def train(args: argparse.Namespace):
         epoch_loss = 0.0
         for batch in loader:
             batch = batch.to(device)
-            mask = torch.stack([generate_n2v_mask(batch.shape[-2:], args.mask_ratio) for _ in range(batch.size(0))])
+            mask = torch.stack(
+                [
+                    generate_n2v_mask(batch.shape[-2:], args.mask_ratio)
+                    for _ in range(batch.size(0))
+                ]
+            )
             noisy, target_pixels = apply_n2v_mask(batch, mask)
             pred = model(noisy)
             loss = n2v_loss(pred, target_pixels, mask)
@@ -75,14 +112,17 @@ def train(args: argparse.Namespace):
         if epoch_loss < best_loss:
             best_loss = epoch_loss
             no_improve = 0
-            torch.save(model.state_dict(), os.path.join(args.output_dir, 'best.pt'))
+            torch.save(
+                model.state_dict(),
+                os.path.join(args.output_dir, "best.pt"),
+            )
         else:
             no_improve += 1
             if no_improve >= args.patience:
-                print('Early stopping')
+                print("Early stopping")
                 break
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args = parse_args()
     train(args)


### PR DESCRIPTION
## Summary
- allow specifying a CSV of image paths to train Noise2Void
- document new `--csv` option in README

## Testing
- `black src/denoising/train_n2v.py`
- `flake8 src/denoising/train_n2v.py`


------
https://chatgpt.com/codex/tasks/task_e_6874548a6fa083319a4db62f07a3290d