### PR TITLE
Limit denoising train script to 20 CSV samples

### DIFF
--- a/src/denoising/train_n2v.py
+++ b/src/denoising/train_n2v.py
@@ -46,7 +46,13 @@ def parse_args() -> argparse.Namespace:
         df = pd.read_csv(args.csv)
         if "filepath" not in df.columns:
             raise ValueError("CSV must contain a 'filepath' column")
-        args.images = df["filepath"].astype(str).tolist()
+        # Limit training to 20 samples when a CSV is provided
+        args.images = (
+            df["filepath"]
+            .sample(n=min(20, len(df)), random_state=42)
+            .astype(str)
+            .tolist()
+        )
 
     if not args.images:
         p.error("Either --images or --csv must be specified")


### PR DESCRIPTION
## Summary
- restrict Noise2Void training to only 20 images when a CSV is provided

## Testing
- `black src/denoising/train_n2v.py --line-length 79`
- `flake8 src/denoising/train_n2v.py`


------
https://chatgpt.com/codex/tasks/task_e_6874a63ed4a483319cb81cb5d0a09044