### PR TITLE
Fix denoising dataset normalization

### DIFF
--- a/src/denoising/dataset.py
+++ b/src/denoising/dataset.py
@@ -14,7 +14,9 @@ def load_image(path: str) -> Image.Image:
 
 def normalize(img: torch.Tensor) -> torch.Tensor:
     """Normalize an image tensor to 0-1 range."""
-    img = img.float() / 255.0
+    img = img.float()
+    if img.max() > 1:
+        img = img / 255.0
     return img
 
 


### PR DESCRIPTION
## Summary
- avoid dividing by 255 twice when creating patches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875969dcbcc83319508ae6c177cc063