### PR TITLE
Ensure spawn start method across training scripts

### DIFF
--- a/train_cv_folds.py
+++ b/train_cv_folds.py
@@ -109,4 +109,5 @@ def main():
 
 
 if __name__ == '__main__':
+    torch.multiprocessing.set_start_method("spawn", force=True)
     main()

--- a/train_ddp.py
+++ b/train_ddp.py
@@ -94,4 +94,5 @@ def main():
 
 
 if __name__ == '__main__':
+    torch.multiprocessing.set_start_method("spawn", force=True)
     main()

--- a/train_region_cv.py
+++ b/train_region_cv.py
@@ -132,4 +132,5 @@ def main():
 
 
 if __name__ == '__main__':
+    torch.multiprocessing.set_start_method("spawn", force=True)
     main()

--- a/train_region_single_cv.py
+++ b/train_region_single_cv.py
@@ -133,5 +133,6 @@ def main():
 
 
 if __name__ == '__main__':
+    torch.multiprocessing.set_start_method("spawn", force=True)
     main()
 


### PR DESCRIPTION
## Summary
- set PyTorch multiprocessing start method to `spawn` before running `main()` in all training scripts

## Testing
- `pytest -q`
- `python train_ddp.py --csv tmp_dataset.csv --epochs 1 --batch-size 1 --num-workers 0 --n-splits 2 --holdout-frac 0.5` *(fails: Tunnel connection failed 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6876d3a2d3748331afe57d591cdeca66