### PR TITLE
Add notebook for creating train/val/test splits

### DIFF
--- a/notebooks/generate_splits.ipynb
+++ b/notebooks/generate_splits.ipynb
@@ -1,0 +1,126 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Train/Val/Test Split Generation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook creates train/validation and test splits from a metadata CSV.\n",
+    "\n",
+    "- **Input**: A single metadata CSV containing columns such as `filepath`, `patient_id`, `pathology`, `region`, and `depth`.\n",
+    "- **Output**: CSV files for a holdout test set and cross-validation train/val splits.\n",
+    "\n",
+    "The utility functions come from `src.data.utils.create_splits_from_single_csv`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "from pathlib import Path\n",
+    "from src.data.utils import create_splits_from_single_csv, analyze_splits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Path to the metadata CSV\n",
+    "csv_path = 'path/to/metadata.csv'\n",
+    "\n",
+    "# Directory where split CSVs will be saved\n",
+    "output_dir = Path('data_splits')\n",
+    "output_dir.mkdir(exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create splits\n",
+    "folds, test_df = create_splits_from_single_csv(csv_path, n_splits=5, holdout_frac=0.2, seed=42)\n",
+    "\n",
+    "# Save test set\n",
+    "test_path = output_dir / 'test.csv'\n",
+    "test_df.to_csv(test_path, index=False)\n",
+    "print(f'Saved test set to {test_path} ({len(test_df)} samples)')\n",
+    "\n",
+    "# Save each fold\n",
+    "for i, (train_df, val_df) in enumerate(folds):\n",
+    "    train_path = output_dir / f'fold_{i}_train.csv'\n",
+    "    val_path = output_dir / f'fold_{i}_val.csv'\n",
+    "    train_df.to_csv(train_path, index=False)\n",
+    "    val_df.to_csv(val_path, index=False)\n",
+    "    print(f'Fold {i}: Train={len(train_df)} -> {train_path}')\n",
+    "    print(f'Fold {i}: Val={len(val_df)} -> {val_path}')\n",
+    "\n",
+    "analysis = analyze_splits(folds, test_df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot class distributions across splits\n",
+    "label_cols = ['pathology', 'region', 'depth']\n",
+    "\n",
+    "def plot_distribution(label):\n",
+    "    records = []\n",
+    "    counts = analysis['test_analysis']['class_distributions'].get(label, {}).get('counts', {})\n",
+    "    for cls, cnt in counts.items():\n",
+    "        records.append({'split': 'test', 'class': cls, 'count': cnt})\n",
+    "    for i, (train_a, val_a) in enumerate(analysis['fold_analyses']):\n",
+    "        tcounts = train_a['class_distributions'].get(label, {}).get('counts', {})\n",
+    "        for cls, cnt in tcounts.items():\n",
+    "            records.append({'split': f'fold{i}_train', 'class': cls, 'count': cnt})\n",
+    "        vcounts = val_a['class_distributions'].get(label, {}).get('counts', {})\n",
+    "        for cls, cnt in vcounts.items():\n",
+    "            records.append({'split': f'fold{i}_val', 'class': cls, 'count': cnt})\n",
+    "    if not records:\n",
+    "        print(f'No data for {label}')\n",
+    "        return\n",
+    "    dist_df = pd.DataFrame(records)\n",
+    "    plt.figure(figsize=(8,4))\n",
+    "    sns.barplot(data=dist_df, x='class', y='count', hue='split')\n",
+    "    plt.title(f'{label} distribution across splits')\n",
+    "    plt.ylabel('Count')\n",
+    "    plt.xticks(rotation=45)\n",
+    "    plt.show()\n",
+    "\n",
+    "for lbl in label_cols:\n",
+    "    plot_distribution(lbl)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `generate_splits.ipynb` to create train/val/test CSVs from a metadata file
- include plots for class distributions across all splits

## Testing
- `python -m json.tool notebooks/generate_splits.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_687a62bb57708331b7029a7ebaf7f79c