### PR TITLE
Add patch size visualization notebook

### DIFF
--- a/notebooks/patch_size_visualization.ipynb
+++ b/notebooks/patch_size_visualization.ipynb
@@ -1,0 +1,82 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Patch Size Visualization\n",
+    "\n",
+    "This notebook demonstrates how to read image paths from a CSV file and display image patches of different sizes. It expects the CSV to contain a `filepath` column pointing to each image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import pandas as pd\n",
+    "from PIL import Image\n",
+    "from pathlib import Path\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Path to your metadata CSV (expects a `filepath` column)\n",
+    "metadata_csv = 'data/metadata.csv'\n",
+    "\n",
+    "# Read dataframe\n",
+    "df = pd.read_csv(metadata_csv)\n",
+    "print(f'Read {len(df)} entries')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Load the first image in the dataframe\n",
+    "img_path = Path(df['filepath'].iloc[0])\n",
+    "img = Image.open(img_path)\n",
+    "\n",
+    "plt.imshow(img, cmap='gray')\n",
+    "plt.title('Full Image')\n",
+    "plt.axis('off')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def center_patch(image: Image.Image, patch_size: int) -> Image.Image:\n",
+    "    \"\"\"Return a center crop patch of the given size.\"\"\"\n",
+    "    w, h = image.size\n",
+    "    left = max((w - patch_size) // 2, 0)\n",
+    "    upper = max((h - patch_size) // 2, 0)\n",
+    "    right = left + patch_size\n",
+    "    lower = upper + patch_size\n",
+    "    return image.crop((left, upper, right, lower))\n",
+    "\n",
+    "patch_sizes = [224, 512]\n",
+    "for size in patch_sizes:\n",
+    "    if size > min(img.size):\n",
+    "        print(f'Skipping {size}x{size} - image is smaller than this')\n",
+    "        continue\n",
+    "    patch = center_patch(img, size)\n",
+    "    plt.imshow(patch, cmap='gray')\n",
+    "    plt.title(f'{size}x{size} Patch')\n",
+    "    plt.axis('off')\n",
+    "    plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add notebook showing image patches at 224 and 512 sizes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a6eb21c648331a45aebe2c6bd63dc