### PR TITLE
Enable multi-GPU processing for CLAHE+NLM script

### DIFF
--- a/apply_clahe_nlm_csv.py
+++ b/apply_clahe_nlm_csv.py
@@ -1,26 +1,71 @@
 import argparse
 import os
+from typing import Optional
+
+import cv2
 import pandas as pd
-from PIL import Image
-import numpy as np
-from skimage import exposure, restoration
+import torch
+import torch.multiprocessing as mp
 from tqdm import tqdm
 
 
-def apply_filters(
-    img: Image.Image, clip_limit: float = 0.2, h: float = 0.15
-) -> Image.Image:
-    """Apply CLAHE and Non-local Means filtering to a PIL Image."""
-    arr = np.array(img.convert("L"), dtype=np.uint8)
-    arr = arr.astype(np.float32) / 255.0
-    arr = exposure.equalize_adapthist(arr, clip_limit=clip_limit)
-    arr = restoration.denoise_nl_means(arr, h=h, fast_mode=True)
-    arr = np.clip(arr, 0.0, 1.0)
-    arr = (arr * 255).astype(np.uint8)
-    return Image.fromarray(arr)
+def apply_filters_cv(
+    path: str,
+    clahe: cv2.CLAHE,
+    h: float,
+    gpu_id: Optional[int] = None,
+) -> Optional[cv2.Mat]:
+    """Apply CLAHE and Fast Non-local Means using OpenCV.
+
+    Parameters
+    ----------
+    path: str
+        Path to the input image.
+    clahe: cv2.CLAHE
+        Preconstructed CLAHE object.
+    h: float
+        Filter strength parameter. Should be scaled for 8-bit images.
+    gpu_id: Optional[int]
+        GPU index to run CUDA denoising on. If ``None`` or CUDA is unavailable,
+        CPU denoising is used instead.
+    """
+    img = cv2.imread(path, cv2.IMREAD_GRAYSCALE)
+    if img is None:
+        return None
+    img = clahe.apply(img)
+    if gpu_id is not None and torch.cuda.is_available():
+        torch.cuda.set_device(gpu_id)
+        gmat = cv2.cuda_GpuMat()
+        gmat.upload(img)
+        out = cv2.cuda.fastNlMeansDenoising(gmat, None, h)
+        img = out.download()
+    else:
+        img = cv2.fastNlMeansDenoising(img, None, h)
+    return img
 
 
-def process_csv(csv_path: str, output_dir: str, clip_limit: float, h: float):
+def _process_dataframe(
+    df: pd.DataFrame,
+    base_dir: str,
+    output_dir: str,
+    clahe: cv2.CLAHE,
+    h: float,
+    gpu_id: Optional[int] = None,
+) -> None:
+    for _, row in tqdm(df.iterrows(), total=len(df), position=gpu_id or 0):
+        inp_path = row["filepath"]
+        result = apply_filters_cv(inp_path, clahe, h, gpu_id)
+        if result is None:
+            continue
+        rel_path = os.path.relpath(inp_path, base_dir)
+        out_path = os.path.join(output_dir, rel_path)
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
+        cv2.imwrite(out_path, result)
+
+
+def process_csv(
+    csv_path: str, output_dir: str, clip_limit: float, h: float
+) -> None:
     df = pd.read_csv(csv_path)
     if "filepath" not in df.columns:
         raise ValueError("CSV must contain a 'filepath' column")
@@ -29,14 +74,9 @@ def process_csv(csv_path: str, output_dir: str, clip_limit: float, h: float):
 
     base_dir = os.path.commonpath(df["filepath"].tolist())
 
-    for _, row in tqdm(df.iterrows(), total=len(df)):
-        inp_path = row["filepath"]
-        img = Image.open(inp_path)
-        filtered = apply_filters(img, clip_limit=clip_limit, h=h)
-        rel_path = os.path.relpath(inp_path, base_dir)
-        out_path = os.path.join(output_dir, rel_path)
-        os.makedirs(os.path.dirname(out_path), exist_ok=True)
-        filtered.save(out_path)
+    clahe = cv2.createCLAHE(clipLimit=clip_limit)
+
+    _process_dataframe(df, base_dir, output_dir, clahe, h * 255.0)
 
 
 def parse_args():
@@ -65,12 +105,36 @@ def parse_args():
         default=0.15,
         help="NLM filter strength",
     )
+    parser.add_argument(
+        "--multi-gpu",
+        action="store_true",
+        help="Use all available GPUs in parallel",
+    )
     return parser.parse_args()
 
 
 def main():
     args = parse_args()
-    process_csv(args.csv, args.output_dir, args.clip_limit, args.h)
+    if args.multi_gpu and torch.cuda.device_count() > 1:
+        world_size = torch.cuda.device_count()
+
+        def _worker(rank: int, args):
+            df = pd.read_csv(args.csv)
+            base_dir = os.path.commonpath(df["filepath"].tolist())
+            clahe = cv2.createCLAHE(clipLimit=args.clip_limit)
+            df = df.iloc[rank::world_size].reset_index(drop=True)
+            _process_dataframe(
+                df,
+                base_dir,
+                args.output_dir,
+                clahe,
+                args.h * 255.0,
+                gpu_id=rank,
+            )
+
+        mp.spawn(_worker, args=(args,), nprocs=world_size)
+    else:
+        process_csv(args.csv, args.output_dir, args.clip_limit, args.h)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- accelerate `apply_clahe_nlm_csv.py` using OpenCV and CUDA
- add option to run across multiple GPUs with `--multi-gpu`

## Testing
- `black -q apply_clahe_nlm_csv.py`
- `flake8 apply_clahe_nlm_csv.py`


------
https://chatgpt.com/codex/tasks/task_e_687a902eda8083319ad72a92916cd144